### PR TITLE
remove limit from exported results

### DIFF
--- a/assets/components/xodus/js/mgr/widgets/xodus.panel.js
+++ b/assets/components/xodus/js/mgr/widgets/xodus.panel.js
@@ -3,7 +3,7 @@ Xodus.panel.Xodus = function(config) {
     Ext.applyIf(config,{
         id: 'xodus-panel-xodus'
         ,url: Xodus.config.connectorUrl
-		,baseParams: { action: 'mgr/xodus/getfile', limit: '0' }
+		,baseParams: { action: 'mgr/xodus/getfile' }
         ,anchor: '98%'
 		,layout:'form'
 		,baseCls:'modx-formpanel'

--- a/core/components/xodus/processors/mgr/xodus/getfile.class.php
+++ b/core/components/xodus/processors/mgr/xodus/getfile.class.php
@@ -32,6 +32,11 @@ class XodusGetGroupUserListProcessor extends modObjectGetListProcessor {
 	private $users = array();
 	private $fext = '';
 	private $timestamp = '';
+
+	public function beforeQuery() {
+		$this->setProperty('limit', 0);
+		return true;
+	}
 	
 	public function prepareQueryBeforeCount(xPDOQuery $c) {
         $usergroup = (int)$this->getProperty('group',0);
@@ -46,11 +51,6 @@ class XodusGetGroupUserListProcessor extends modObjectGetListProcessor {
 		$c->select(array('modUser.id','modUser.username','modUser.password'));
 		return $c;
     }
-	
-	public function prepareQueryAfterCount(xPDOQuery $c) {
-		$c->limit(0);
-       	return $c;	
-	}
 	
 	public function prepareRow(xPDOObject $obj){
 		$profile = $obj->getOne('Profile');


### PR DESCRIPTION
By default, since it's using modObjectGetListProcessor the exported results are limited to 20.  I've added a limit of 0 to the baseParams of the Ext panel to get around this.
