### PR TITLE
Fixed "break not in the loop or switch context in"

### DIFF
--- a/core/components/xodus/lib/excel/Classes/PHPExcel/Calculation/Functions.php
+++ b/core/components/xodus/lib/excel/Classes/PHPExcel/Calculation/Functions.php
@@ -571,7 +571,6 @@ class PHPExcel_Calculation_Functions {
 				return 4;
 		} elseif(is_array($value)) {
 				return 64;
-				break;
 		} elseif(is_string($value)) {
 			//	Errors
 			if ((strlen($value) > 0) && ($value{0} == '#')) {


### PR DESCRIPTION
PHP 7.0 and higher, a break statement is no longer permitted outside a for, foreach or switch statement and gives a fatal error.
